### PR TITLE
General performance improvements

### DIFF
--- a/SimpleNatsClient/Connection/NatsParser.cs
+++ b/SimpleNatsClient/Connection/NatsParser.cs
@@ -58,7 +58,9 @@ namespace SimpleNatsClient.Connection
                     {
                         _state = State.Payload;
                         _nextMessage = message;
-                        _expectedPayloadSize = int.Parse(message.Split(' ').Last());
+
+                        var lastSpace = message.LastIndexOf(' ');
+                        _expectedPayloadSize = int.Parse(message.Substring(lastSpace));
                         _nextPayload = new byte[_expectedPayloadSize];
                         Parse(buffer, i + 1, count - i - 1);
                         return;

--- a/SimpleNatsClient/NatsClient.cs
+++ b/SimpleNatsClient/NatsClient.cs
@@ -20,6 +20,8 @@ namespace SimpleNatsClient
         private readonly IObservable<IncomingMessage> _inbox;
         private readonly string _inboxPrefix = $"_INBOX.{Guid.NewGuid():N}.";
 
+        private long _inboxSuffix = 0;
+
         public INatsConnection Connection { get; }
 
         public NatsClient(INatsConnection connection)
@@ -34,7 +36,7 @@ namespace SimpleNatsClient
 
         public string NewInbox()
         {
-            return _inboxPrefix + Guid.NewGuid().ToString("N");
+            return _inboxPrefix + Interlocked.Increment(ref _inboxSuffix);
         }
 
         public Task Publish(string subject, CancellationToken cancellationToken = default(CancellationToken))


### PR DESCRIPTION
This PR adds some general performance improvements to the client by reducing allocations.

- Remove `String.Split` when not needed
- Replace `Guid.NewGuid` with an interlocked `long` (see https://github.com/nats-io/csharp-nats/pull/167) for inbox subjects
- Avoid allocating an empty byte sequence for empty incoming message payloads